### PR TITLE
Tweaks

### DIFF
--- a/opam-grep.sh
+++ b/opam-grep.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DST="$HOME/.opam-grep"
+DST="$HOME/.cache/opam-grep"
 PACKAGES="$DST/packages"
 
 sync() {
@@ -9,7 +9,7 @@ sync() {
 }
 
 check() {
-  if [ ! -e "$DST/$1" ]; then
+  if test ! -e "$DST/$1"; then
     opam source --dir "$DST/$1" "$1" > /dev/null
   fi
 }


### PR DESCRIPTION
I was impatient to get results without having to wait for `setup` to finish and also cussing that I hadn't kept the directory from `/tmp` the last time I used it (with 10TiB local storage, the download time dominates...!)

A few very rapidly hacked tweaks, if of interest:

- Cache packages in `~/.opam-grep` (download time more precious than disk)
- Allow searching at the same time as the first download
- Spinner (obviously...!)

As I've done it here, the package list is put in `~/.opam-grep/packages` and that can be refreshed manually with `opam-grep.sh update`. It's an optional step, though - `opam-grep.sh grep` will automatically update `opam-grep.sh update` has never been run.

I didn't implement it, but `opam-grep.sh prune` is intended to get rid of old versions of packages... at the moment you'd get multiple matches. Equally, that step could just be included in the `update` function.