### PR TITLE
WIP: use opam library rather than the tool

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -6,7 +6,8 @@
   cmdliner
   fpath
   bos
-  opam-repository))
+  opam-repository
+  opam-client))
 
 (rule
  (target config.ml)

--- a/src/dune
+++ b/src/dune
@@ -5,7 +5,8 @@
   progress
   cmdliner
   fpath
-  bos))
+  bos
+  opam-repository))
 
 (rule
  (target config.ml)


### PR DESCRIPTION
First commit is much less hideous than the second!

Basic premise is to use a git clone of opam-repository to get the package list. That's much faster than `opam list` which affects every call to `opam grep`.

There's loads still to fix in all this, obviously...